### PR TITLE
Change definition from minion to node for consistency

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -10,7 +10,7 @@ Before looking into it you must know the workflow of the software, Skyflash will
 
 1. Select and verify a Skybian base image, either from a local file or downloading a copy from the internet.
 2. Setting your particular network configuration (default Skycoin's Skyminers config is suggested)
-3. Build the images for a manager and how many minions you like (in actual skywire testnet only a manager and 7 minions are allowed)
+3. Build the images for a manager and how many nodes you like (in actual skywire testnet only a manager and 7 nodes are allowed)
 4. [Optionally] Burn the images to uSDCards to insert into your Orange Pi Prime SBC.
 
 Now we will explore each option in depth
@@ -79,7 +79,7 @@ The app has some logic rules you need to obey when modifying the network setting
 * We use a `/24` network segment (255.255.255.0 netmask if you prefer it on this format)
 * Because of that the `Manager IP` address must need to be in the same network segment of the `Gateway`.
 * We use CloudFlare/OpenDNS DNS servers instead of Google ones, if you want to use a local one put it first and keep a CloudFlare/OpenDNS DNS servers in second place.
-* The minion's count refers to the minions only (7 minions + one manager), we assume you want to always config a managers node; because of this you can also specify a count of 0 minions and the app will only create a manager node image with no minions (useful for a quick test of the overall work flow)
+* The node count refers to the nodes only (7 nodes + one manager), we assume you want to always config a managers node; because of this you can also specify a count of 0 nodes and the app will only create a manager node image with no nodes (useful for a quick test of the overall work flow)
 
 If you manage to break some of this rules (and other trivial ones) the app will complain suggesting where the trouble is.
 
@@ -95,7 +95,7 @@ During the image generation you may see a windows like this to show you the proc
 
 ![Building images](/images/images.png)
 
-When this process finish you will have the images in your Skybian folder, they will have names like `Skybian-manager.img` & `Skybian-minion-1.img` and so on.
+When this process finish you will have the images in your Skybian folder, they will have names like `Skybian-manager.img` & `Skybian-node-1.img` and so on.
 
 ## Step #4: Flashing the images
 

--- a/skyflash-cli_MANUAL.md
+++ b/skyflash-cli_MANUAL.md
@@ -28,24 +28,24 @@ For a default configuration of skybian as a skyminer you just need to run it lik
 
 Where "Skybian-0.1.0.img" is the skybian base image you have downloaded.
 
-This will generate 8 images, one for the manager and 7 minions. Network configuration is the skyminers default:
+This will generate 8 images, one for the manager and 7 nodes. Network configuration is the skyminers default:
 
 * Network: 192.168.0.0/24
 * Netmask: 255.255.255.0 (aka: /24)
 * Gateway: 192.168.0.1
 * DNS servers: 1.0.0.1, 1.1.1.1
 * Manager IP: 192.168.0.2
-* Minions IPs: 192.168.0.[3-9] (7 minions)
+* nodes IPs: 192.168.0.[3-9] (7 nodes)
 
-If you need a different setup just check the `skyflash-cli -h` to know more, for example for a manager and 22 minions with this details:
+If you need a different setup just check the `skyflash-cli -h` to know more, for example for a manager and 22 nodes with this details:
 
 * Network: 172.16.22.0/24
 * Gateway: 172.16.22.1
 * DNS servers: 172.16.22.1, 1.1.1.1
 * Manager: 172.16.22.10
-* Minions: 172.16.22.100 to 172.16.22.121
+* nodes: 172.16.22.100 to 172.16.22.121
 
-**Tip:** If you don't care about the minions IP being contiguous you can declare a range that is greater than the minions count and the script will allocate the IPs in a scattered way inside the range you stated.
+**Tip:** If you don't care about the nodes IP being contiguous you can declare a range that is greater than the nodes count and the script will allocate the IPs in a scattered way inside the range you stated.
 
 ```sh
 ./skyflash-cli -g 172.16.22.1 -d "172.16.22.1, 1.1.1.1" -m 172.16.22.10 -n 100-121 -i Skybian-0.1.0.img

--- a/skyflash/data/skyflash.qml
+++ b/skyflash/data/skyflash.qml
@@ -303,7 +303,7 @@ ApplicationWindow {
                 }
 
                 // node count
-                Label { text: "Minions count:" }
+                Label { text: "Node count:" }
 
                 TextField  {
                     id: txtNodes
@@ -313,7 +313,7 @@ ApplicationWindow {
                     maximumLength: 5
                     enabled: false
                     inputMask: "000"
-                    // ToolTip.text: "How many minions we must build images for, not counting the manager node"
+                    // ToolTip.text: "How many nodes we must build images for, not counting the manager node"
                 }
             }
         }

--- a/skyflash/skyflash.py
+++ b/skyflash/skyflash.py
@@ -934,15 +934,15 @@ To flash the next image just follow these steps:
         endip = int(manager[manager.rfind('.') + 1:]) + int(nodes)
         if endip > 255:
             self.uiError.emit("Validation error", "The nodes IP distribution is beyond 255, please lower your manager ip",
-                "The IP of the minions are distributed from the manager IP and up, if you set the manager node IP so high the minion count may not fit")
-            logging.debug("Manager IP to high, last minion will be {} and that's not possible".format(endip))
+                "The IP of the nodes are distributed from the manager IP and up, if you set the manager node IP so high the node count may not fit")
+            logging.debug("Manager IP to high, last node will be {} and that's not possible".format(endip))
             return False
 
         # validation #5, gw not in manager & nodes range
         if int(gw[gw.rfind('.') + 1:]) in range(int(manager[manager.rfind('.') + 1:]), endip):
-            self.uiError.emit("Validation error", "Please check your GW, Manager & Minion selection, the GW is one of the Minions or Manager IPs",
-                "When we distribute the manager & Minions IP we found that the GW is one of that IP and that's wrong")
-            logging.debug("GW ip is on generated Minions range.")
+            self.uiError.emit("Validation error", "Please check your GW, Manager & Nodes selection, the GW is one of the Nodes or Manager IPs",
+                "When we distribute the manager & nodes IP we found that the GW is one of that IP and that's wrong")
+            logging.debug("GW ip is on generated nodes range.")
             return False
 
         # If you reached this point then all is ok
@@ -1038,7 +1038,7 @@ To flash the next image just follow these steps:
             # new file and it's name
             nodeNick = "manager"
             if nip != self.netManager:
-                nodeNick = "minion-" + str(actual)
+                nodeNick = "node-" + str(actual)
 
             nodeName = "Skybian-" + nodeNick + ".img"
 


### PR DESCRIPTION
Fixes #26 

Changes:
- All appearances of the term "minon" for the correct one: "node"

Does this change need to mentioned in CHANGELOG.md?
No

