### PR TITLE
Change the url to open for the user's manual

### DIFF
--- a/skyflash/skyflash.py
+++ b/skyflash/skyflash.py
@@ -32,7 +32,7 @@ imageConfigDataSize = 256
 
 # skybian URL
 skybianUrl = "https://github.com/skycoin/skybian/releases/download/Skybian-v0.0.4/Skybian-v0.0.4.tar.xz"
-manualUrl = "https://github.com/skycoin/skyflash/blob/develop/USER_MANUAL.md"
+manualUrl = "https://github.com/skycoin/skyflash/blob/master/USER_MANUAL.md"
 
 
 class Skyflash(QObject):


### PR DESCRIPTION
Fixes #30 

Changes:
- The URL that points to the users's manual, was pointing to the develop branch, switched to master branch

Does this change need to mentioned in CHANGELOG.md?
No

