### PR TITLE
Displaying the base image file and version when it's logical to do so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Dates must be YEAR-MONTH-DAY
 - Full generation of release files via Travis
 - Make now can take care of dependencies in linux
 - Doc update with latest changes
+- UI now shows the name and version of the base image being processed.
 
 ### Changed
 


### PR DESCRIPTION
Fixes #32 

Changes:
- UI, logs & logic inside, it now shows the image being processed (downloaded, extracted, etc..) an the image has the version number in the name.

Does this change need to mentioned in CHANGELOG.md?
Yes, already mentioned.

