### PR TITLE
Add write speed and time left to the infos on the flash stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## UNRELEASED
+
+### Changed
+
+- Some UI improvements and fixes: reformat the about box, fix the grammar of a sentences and delay the browser popup after the "new version of skyflash" is detected.
+
+### Added
+
+- Now the flashing process shows the write speed and the time left (both as average of the whole flash process)
+
 ## v0.0.5 - 2019-07-19
 
 ### Fixed

--- a/skyflash/skyflash.py
+++ b/skyflash/skyflash.py
@@ -1411,6 +1411,7 @@ To flash the next image just follow these steps:
         drive = self.card
         logfile = os.path.join(tempfile.gettempdir(), "skfpl.log")
         flasher = "flash.exe"
+        size = os.path.getsize(image)
 
         # touch (& truncate) the logfile
         f = open(logfile, 'wt')
@@ -1432,6 +1433,7 @@ To flash the next image just follow these steps:
 
         try:
             p = subprocess.Popen(cmd)
+            flash_start = time.time()
 
             #  open the log file
             lf = open(logfile, 'rt')
@@ -1440,6 +1442,9 @@ To flash the next image just follow these steps:
                 #  capturing progress via a file
                 l = lf.readline().strip("\n")
                 if len(l) != 0:
+                    # get time
+                    now_time = time.time()
+
                     # check for errors
                     if l.startswith("ERROR"):
                         print("Error detected:\n{}".format(l))
@@ -1449,7 +1454,8 @@ To flash the next image just follow these steps:
                         # we are on:
                         pr = float(l.strip()[:-1])
                         if pr > 0:
-                            progress_callback.emit(pr, "Flashing {}: {}%".format(name, pr))
+                            (speed, eta) = calc_speed_eta(size, pr, flash_start, now_time)
+                            progress_callback.emit(pr, "Flashing {}: {}%, {}, {} left".format(name, pr, speed, eta))
 
             #  close the log file
             if lf:

--- a/skyflash/skyflash.py
+++ b/skyflash/skyflash.py
@@ -1604,6 +1604,7 @@ To flash the next image just follow these steps:
 
             try:
                 p = subprocess.Popen(realcmd, shell=True)
+                flash_start = time.time()
 
                 #  open the log file
                 lf = open(logfile, 'r')
@@ -1612,6 +1613,9 @@ To flash the next image just follow these steps:
                     #  capturing progress via a file
                     l = lf.readline().strip("\n")
                     if len(l) != 0:
+                        # get time
+                        now_time = time.time()
+
                         # check for errors
                         if l.startswith("ERROR"):
                             print("Error detected:\n{}".format(l))
@@ -1621,7 +1625,8 @@ To flash the next image just follow these steps:
                             # we are on:
                             pr = float(l.strip()[:-1])
                             if pr > 0:
-                                progress_callback.emit(pr, "Flashing {}: {}%".format(name, pr))
+                                (speed, eta) = calc_speed_eta(size, pr, flash_start, now_time)
+                                progress_callback.emit(pr, "Flashing {}: {}%, {}, {} left".format(name, pr, speed, eta))
 
                 #  close the log file
                 if lf:

--- a/skyflash/utils.py
+++ b/skyflash/utils.py
@@ -741,3 +741,27 @@ def eraseOldVersions(dlfolder, version):
             print("Item does not match version, erasing if file")
             if os.path.isfile(item):
                 os.unlink(item)
+
+def calc_speed_eta(size, pr, start_time, time_now):
+    '''Calculate the write speed and remaining time from a few values
+    
+    Output format must be strings ready to print, like this:
+    6.2 MBytes/s, 8 minutes 22 seconds
+    '''
+
+    try:
+        # initial calcs
+        time_delta = time_now - start_time
+        wrote = size * pr / 100
+        remains = size - wrote
+
+        # speed from the time spent in writing the actual amount
+        lspeed = wrote / time_delta
+
+        # estimated time for completion
+        leta = int(remains / lspeed)
+    
+    except ZeroDivisionError: 
+        return ("please", "wait...")
+
+    return (speed(lspeed), eta(leta)) 


### PR DESCRIPTION
Fixes #79 

Changes:
- Adds the procedures to calculate the speed and remaining time for the flashing to end
- Adds the visual values in each OS flash procedure

Does this change need to mentioned in CHANGELOG.md?
Yes, already mentioned
